### PR TITLE
Add CI matrix generation workflow

### DIFF
--- a/.github/workflows/generate-ci-matrix.yml
+++ b/.github/workflows/generate-ci-matrix.yml
@@ -1,0 +1,51 @@
+name: "Generate CI matrix"
+
+on:
+  workflow_call:
+    inputs:
+      glpi-version:
+        required: true
+        type: string
+    outputs:
+      matrix:
+        value: ${{ jobs.generate-ci-matrix.outputs.matrix }}
+
+jobs:
+  generate-ci-matrix:
+    name: "Generate CI matrix"
+    runs-on: "ubuntu-latest"
+    outputs:
+      matrix: ${{ steps.generate-ci-matrix.outputs.matrix }}
+    steps:
+      - name: "Generate CI matrix"
+        id: "generate-ci-matrix"
+        run: |
+          if [[ "${{ inputs.glpi-version }}" = "10.0.x" ]]; then
+            MATRIX='
+              {
+                "include": [
+                  {"glpi-version": "10.0.x", "php-version": "7.4", "db-image": "mysql:8.0"},
+                  {"glpi-version": "10.0.x", "php-version": "8.0", "db-image": "mysql:8.0"},
+                  {"glpi-version": "10.0.x", "php-version": "8.1", "db-image": "mysql:8.0"},
+                  {"glpi-version": "10.0.x", "php-version": "8.2", "db-image": "mysql:8.0"},
+                  {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mysql:8.0"},
+                  {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mysql:5.7"},
+                  {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mariadb:10.2"},
+                  {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mariadb:10.11"}
+                ]
+              }
+            '
+          elif [[ "${{ inputs.glpi-version }}" = "10.1.x" ]]; then
+            MATRIX='
+              {
+                "include": [
+                  {"glpi-version": "10.1.x", "php-version": "8.1", "db-image": "mysql:8.0"},
+                  {"glpi-version": "10.1.x", "php-version": "8.2", "db-image": "mysql:8.0"},
+                  {"glpi-version": "10.1.x", "php-version": "8.3", "db-image": "mysql:8.0"},
+                  {"glpi-version": "10.1.x", "php-version": "8.3", "db-image": "mariadb:10.5"},
+                  {"glpi-version": "10.1.x", "php-version": "8.3", "db-image": "mariadb:10.11"}
+                ]
+              }
+            '
+          fi
+          echo "matrix=$(echo $MATRIX | jq -c .)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Each plugin that uses the `glpi-project/plugin-ci-workflows/.github/workflows/continuous-integration.yml@v1` workflow have to declare its own test matrix. It means that there are many duplicated declarations that have to be updated, for instance, when a new PHP version is released. For instance, many matrixes are still using PHP 8.3-rc because they have not been updated since the PHP 8.3 stable release.

With this new workflow, plugins will get the default matrix to use for a given GLPI version.

Before:
```yaml
jobs:
  ci:
    name: "GLPI ${{ matrix.glpi-version }} - php:${{ matrix.php-version }} - ${{ matrix.db-image }}"
    strategy:
      fail-fast: false
      matrix:
        include:
          - {glpi-version: "10.0.x", php-version: "7.4", db-image: "mysql:5.7"}
          - {glpi-version: "10.0.x", php-version: "8.0", db-image: "mysql:8.0"}
          - {glpi-version: "10.0.x", php-version: "8.1", db-image: "mariadb:10.2"}
          - {glpi-version: "10.0.x", php-version: "8.2", db-image: "mariadb:11.0"}
          - {glpi-version: "10.0.x", php-version: "8.3-rc", db-image: "mysql:8.0"}
    uses: "glpi-project/plugin-ci-workflows/.github/workflows/continuous-integration.yml@v1"
    with:
      plugin-key: "credit"
      glpi-version: "${{ matrix.glpi-version }}"
      php-version: "${{ matrix.php-version }}"
      db-image: "${{ matrix.db-image }}"
```

After:
```yaml
jobs:
  generate-ci-matrix:
    name: "Generate CI matrix"
    uses: "glpi-project/plugin-ci-workflows/.github/workflows/generate-ci-matrix.yml@v1"
    with:
      glpi-version: "10.0.x"
  ci:
    name: "GLPI ${{ matrix.glpi-version }} - php:${{ matrix.php-version }} - ${{ matrix.db-image }}"
    needs: "generate-ci-matrix"
    strategy:
      fail-fast: false
      matrix: ${{ fromJson(needs.generate-ci-matrix.outputs.matrix) }}
    uses: "glpi-project/plugin-ci-workflows/.github/workflows/continuous-integration.yml@v1"
    with:
      plugin-key: "credit"
      glpi-version: "${{ matrix.glpi-version }}"
      php-version: "${{ matrix.php-version }}"
      db-image: "${{ matrix.db-image }}"
```

Exemple of this new worflow usage : https://github.com/cedric-anne/glpi-plugin-credit/actions/runs/7712614183