### PR TITLE
Limit default CI matrix to min/max PHP/MariaDB versions

### DIFF
--- a/.github/workflows/generate-ci-matrix.yml
+++ b/.github/workflows/generate-ci-matrix.yml
@@ -6,6 +6,10 @@ on:
       glpi-version:
         required: true
         type: string
+      complete-matrix:
+        required: false
+        type: boolean
+        default: false
     outputs:
       matrix:
         value: ${{ jobs.generate-ci-matrix.outputs.matrix }}
@@ -21,31 +25,53 @@ jobs:
         id: "generate-ci-matrix"
         run: |
           if [[ "${{ inputs.glpi-version }}" = "10.0.x" ]]; then
-            MATRIX='
-              {
-                "include": [
-                  {"glpi-version": "10.0.x", "php-version": "7.4", "db-image": "mysql:8.0"},
-                  {"glpi-version": "10.0.x", "php-version": "8.0", "db-image": "mysql:8.0"},
-                  {"glpi-version": "10.0.x", "php-version": "8.1", "db-image": "mysql:8.0"},
-                  {"glpi-version": "10.0.x", "php-version": "8.2", "db-image": "mysql:8.0"},
-                  {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mysql:8.0"},
-                  {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mysql:5.7"},
-                  {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mariadb:10.2"},
-                  {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mariadb:10.11"}
-                ]
-              }
-            '
+            if [[ "${{ inputs.complete-matrix && 'true' || 'false' }}" = "true" ]]; then
+              MATRIX='
+                {
+                  "include": [
+                    {"glpi-version": "10.0.x", "php-version": "7.4", "db-image": "mysql:8.0"},
+                    {"glpi-version": "10.0.x", "php-version": "8.0", "db-image": "mysql:8.0"},
+                    {"glpi-version": "10.0.x", "php-version": "8.1", "db-image": "mysql:8.0"},
+                    {"glpi-version": "10.0.x", "php-version": "8.2", "db-image": "mysql:8.0"},
+                    {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mysql:8.0"},
+                    {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mysql:5.7"},
+                    {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mariadb:10.2"},
+                    {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mariadb:10.11"}
+                  ]
+                }
+              '
+            else
+              MATRIX='
+                {
+                  "include": [
+                    {"glpi-version": "10.0.x", "php-version": "7.4", "db-image": "mariadb:10.2"},
+                    {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mariadb:10.11"}
+                  ]
+                }
+              '
+            fi
           elif [[ "${{ inputs.glpi-version }}" = "10.1.x" ]]; then
-            MATRIX='
-              {
-                "include": [
-                  {"glpi-version": "10.1.x", "php-version": "8.1", "db-image": "mysql:8.0"},
-                  {"glpi-version": "10.1.x", "php-version": "8.2", "db-image": "mysql:8.0"},
-                  {"glpi-version": "10.1.x", "php-version": "8.3", "db-image": "mysql:8.0"},
-                  {"glpi-version": "10.1.x", "php-version": "8.3", "db-image": "mariadb:10.5"},
-                  {"glpi-version": "10.1.x", "php-version": "8.3", "db-image": "mariadb:10.11"}
-                ]
-              }
-            '
+            if [[ "${{ inputs.complete-matrix && 'true' || 'false' }}" = "true" ]]; then
+              MATRIX='
+                {
+                  "include": [
+                    {"glpi-version": "10.1.x", "php-version": "8.1", "db-image": "mysql:8.0"},
+                    {"glpi-version": "10.1.x", "php-version": "8.2", "db-image": "mysql:8.0"},
+                    {"glpi-version": "10.1.x", "php-version": "8.3", "db-image": "mysql:8.0"},
+                    {"glpi-version": "10.1.x", "php-version": "8.3", "db-image": "mariadb:10.5"},
+                    {"glpi-version": "10.1.x", "php-version": "8.3", "db-image": "mariadb:10.11"}
+                  ]
+                }
+              '
+            else
+              MATRIX='
+                {
+                  "include": [
+                    {"glpi-version": "10.0.x", "php-version": "8.1", "db-image": "mariadb:10.5"},
+                    {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mariadb:10.11"}
+                  ]
+                }
+              '
+            fi
           fi
           echo "matrix=$(echo $MATRIX | jq -c .)" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ The `db-image` parameter is a combination of the DB server engine (`mysql`, `mar
 
 ## Generate CI matrix
 
-This workflow can be used to generate a matrix that contains all the PHP/SQL versions that are supported by the target GLPI version.
-You can use it in combination with the `Continuous Integration` workflow to execute the continuous integration
-test suite on all PHP/SQL versions supported by the target version of GLPI, as shown in the example below.
+This workflow can be used to generate a matrix that contains the default PHP/SQL versions that are supported by the target GLPI version.
+You can use it in combination with the `Continuous Integration` workflow, as shown in the example below.
 
 ```yaml
 name: "Continuous integration"
@@ -76,6 +75,10 @@ jobs:
     uses: "glpi-project/plugin-ci-workflows/.github/workflows/generate-ci-matrix.yml@v1"
     with:
       glpi-version: "10.0.x"
+
+      # Whether the complete compatibility matrix should be generated.
+      # Default: false
+      complete-matrix: true
   ci:
     name: "GLPI ${{ matrix.glpi-version }} - php:${{ matrix.php-version }} - ${{ matrix.db-image }}"
     needs: "generate-ci-matrix"


### PR DESCRIPTION
In order to reduce the CI consumption, I propose to limit the default CI matrix to:
 - min PHP + min MariaDB supported version,
 - max PHP + max MariaDB supported version.

It would still be possible to generate the full compatibility matrix using the `complete-matrix: true` input parameter.