### PR TITLE
fix: --db-password option value cannot be null

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -138,7 +138,7 @@ jobs:
       - name: "Install plugin"
         working-directory: "/var/www/glpi"
         run: |
-          bin/console database:install --ansi --no-interaction --db-name=glpi --db-host=db --db-user=root --strict-configuration
+          bin/console database:install --ansi --no-interaction --db-name=glpi --db-host=db --db-user=root --db-password="" --strict-configuration
           bin/console plugin:install --ansi --no-interaction --username=glpi ${{ inputs.plugin-key }}
           bin/console plugin:activate --ansi --no-interaction ${{ inputs.plugin-key }}
       - name: "Run apache"


### PR DESCRIPTION
Fix error with `glpi-version: "11.0.x"`:

![image](https://github.com/user-attachments/assets/84c68f62-a98d-44f0-be8f-5d235be75824)

```
Run bin/console database:install --ansi --no-interaction --db-name=glpi --db-host=db --db-user=root --strict-configuration
Some optional system requirements are missing. Run the "php bin/console system:check_requirements" command for more details.

                                              
  --db-password option value cannot be null.  
                                              

database:install [-H|--db-host [DB-HOST]] [-d|--db-name DB-NAME] [-p|--db-password [DB-PASSWORD]] [-P|--db-port [DB-PORT]] [-u|--db-user DB-USER] [-r|--reconfigure] [--strict-configuration] [-L|--default-language [DEFAULT-LANGUAGE]] [-f|--force] [--enable-telemetry] [--no-telemetry]

Error: Process completed with exit code 1.
```