### PR TITLE
Feat: allow installation of the sqlsrv extension

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,13 +50,11 @@ jobs:
         uses: "actions/checkout@v4"
         with:
             path: "${{ inputs.plugin-key }}"
-      - name: "Additionnal scripts"
+      - name: "Additionnal script"
         if: ${{ inputs.init-script != '' }}
         shell: "bash"
         run: |
-          echo "${{ inputs.init-script }}" > /tmp/init-script.sh
-          chmod +x /tmp/init-script.sh
-          /tmp/init-script.sh
+          env --ignore-environment bash --noprofile --norc ${{ inputs.init-script }}
       - name: "Configure cache directories"
         # Use default `bash` shell with `github-actions-runner` user
         shell: "bash"
@@ -146,20 +144,6 @@ jobs:
           else
             echo -e "\033[0;33mLicence headers checks skipped.\033[0m"
           fi
-      - name: "Install sqlsrv extension"
-        if: ${{ inputs.install-sqlsrv-extension == 'true' }}
-        shell: "bash"
-        run: |
-          sudo apt-get update -yq
-          sudo apt-get install -yq unixodbc-dev
-          if [[ "${{ inputs.php-version }}" == "7.4" ]]; then
-            sudo pecl install sqlsrv-5.10.1
-          elif [[ "${{ inputs.php-version }}" == "8.0" ]]; then
-            sudo pecl install sqlsrv-5.11.0
-          else
-            sudo pecl install sqlsrv
-          fi
-          echo "extension=sqlsrv.so" | sudo tee -a /usr/local/etc/php/php.ini
       - name: "Install plugin"
         working-directory: "/var/www/glpi"
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,7 +50,7 @@ jobs:
         uses: "actions/checkout@v4"
         with:
             path: "${{ inputs.plugin-key }}"
-      - name: "Additionnal script"
+      - name: "Execute init script"
         if: ${{ inputs.init-script != '' }}
         shell: "bash"
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,10 +15,10 @@ on:
       db-image:
         required: true
         type: string
-      install-sqlsrv-extension:
+      init-script:
         required: false
         type: string
-        default: "false"
+        default: ""
 
 jobs:
   ci:
@@ -50,6 +50,13 @@ jobs:
         uses: "actions/checkout@v4"
         with:
             path: "${{ inputs.plugin-key }}"
+      - name: "Additionnal scripts"
+        if: ${{ inputs.init-script != '' }}
+        shell: "bash"
+        run: |
+          echo "${{ inputs.init-script }}" > /tmp/init-script.sh
+          chmod +x /tmp/init-script.sh
+          /tmp/init-script.sh
       - name: "Configure cache directories"
         # Use default `bash` shell with `github-actions-runner` user
         shell: "bash"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,6 +15,10 @@ on:
       db-image:
         required: true
         type: string
+      install-sqlsrv-extension:
+        required: false
+        type: string
+        default: "false"
 
 jobs:
   ci:
@@ -135,6 +139,20 @@ jobs:
           else
             echo -e "\033[0;33mLicence headers checks skipped.\033[0m"
           fi
+      - name: "Install sqlsrv extension"
+        if: ${{ inputs.install-sqlsrv-extension == 'true' }}
+        shell: "bash"
+        run: |
+          sudo apt-get update -yq
+          sudo apt-get install -yq unixodbc-dev
+          if [[ "${{ inputs.php-version }}" == "7.4" ]]; then
+            sudo pecl install sqlsrv-5.10.1
+          elif [[ "${{ inputs.php-version }}" == "8.0" ]]; then
+            sudo pecl install sqlsrv-5.11.0
+          else
+            sudo pecl install sqlsrv
+          fi
+          echo "extension=sqlsrv.so" | sudo tee -a /usr/local/etc/php/php.ini
       - name: "Install plugin"
         working-directory: "/var/www/glpi"
         run: |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ jobs:
 
       # The database docker image on which to run the tests.
       db-image: "mariadb:11.4"
+
+      # Optional initialization script that can be used, for instance, to install additional system dependencies.
+      init-script: "./.github/workflows/init-script.sh"
 ```
 
 The available `glpi-version`/`php-version` combinations corresponds to the `ghcr.io/glpi-project/githubactions-glpi-apache` images tags
@@ -48,6 +51,9 @@ The `db-image` parameter is a combination of the DB server engine (`mysql`, `mar
 - MariaDB available versions are listed [here](https://github.com/orgs/glpi-project/packages/container/githubactions-mariadb/versions?filters%5Bversion_type%5D=tagged)
 - MySQL available versions are listed [here](https://github.com/orgs/glpi-project/packages/container/githubactions-mysql/versions?filters%5Bversion_type%5D=tagged).
 - Percona available versions are listed [here](https://github.com/orgs/glpi-project/packages/container/githubactions-percona/versions?filters%5Bversion_type%5D=tagged).
+
+An optional `init-script` parameter can be used to define the path of an initialization script. This script will be executed with `bash`.
+It can be used, for instance, to install a specific PHP extension.
 
 ## Generate CI matrix
 


### PR DESCRIPTION
Allow installation of the sqlsrv extension which is required to install the SCCM plugin.

_Tests carried out in the PR: https://github.com/pluginsGLPI/sccm/pull/132_