### PR TITLE
Force `GLPI_ENVIRONMENT_TYPE=testing` when executing apache server

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -135,7 +135,7 @@ jobs:
         # Use default `bash` shell with `github-actions-runner` user
         shell: "bash"
         run: |
-          sudo service apache2 start
+          sudo env GLPI_ENVIRONMENT_TYPE=testing service apache2 start
       - name: "PHPUnit"
         if: ${{ hashFiles(format('{0}/phpunit.xml', inputs.plugin-key)) != '' }}
         run: |


### PR DESCRIPTION
According to the debug job https://github.com/glpi-network/scim/actions/runs/15704614737/job/44247401368#step:19:479, the `GLPI_ENVIRONMENT_TYPE` does not seems to be properly defined when the apache server is started.