### PR TITLE
Do not override `GLPI_ENVIRONMENT_TYPE` defined by the docker image

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,7 +41,7 @@ jobs:
     defaults:
       run:
         # By default, execute commands using the `www-data` user to prevent rights issues on GLPI generated files.
-        shell: "sudo --set-home --user=www-data env GLPI_ENVIRONMENT_TYPE=testing bash --noprofile --norc -eo pipefail {0}"
+        shell: "sudo --set-home --user=www-data --preserve-env bash --noprofile --norc -eo pipefail {0}"
         working-directory: "/var/www/glpi/plugins/${{ inputs.plugin-key }}"
     env:
       CACHE_DIR: "/home/www-data/.cache/continuous-integration-workflow"
@@ -52,9 +52,10 @@ jobs:
           path: "${{ inputs.plugin-key }}"
       - name: "Execute init script"
         if: ${{ inputs.init-script != '' }}
+        # Use default `bash` shell with `github-actions-runner` user
         shell: "bash"
         run: |
-          env GLPI_ENVIRONMENT_TYPE=testing bash --noprofile --norc ${{ inputs.init-script }}
+          bash --noprofile --norc ${{ inputs.init-script }}
       - name: "Configure cache directories"
         if: ${{ !cancelled() }}
         # Use default `bash` shell with `github-actions-runner` user


### PR DESCRIPTION
The `GLPI_ENVIRONMENT_TYPE` is already defined in the docker image. There is no need to redefine it again everywhere.