### PR TITLE
Fix: composer install warning

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -87,6 +87,9 @@ jobs:
       - name: "Install composer dependencies"
         if: ${{ !cancelled() && hashFiles(format('{0}/composer.json', inputs.plugin-key)) != '' }}
         run: |
+          echo -e "\033[0;33mMark plugin directory as safe...\033[0m"
+          git config --global --add safe.directory "/var/www/glpi/plugins/${{ inputs.plugin-key }}"
+          echo -e "\033[0;33mExecuting Composer install...\033[0m"
           composer install --ansi --no-interaction --no-progress --prefer-dist
       - name: "Install npm dependencies"
         if: ${{ !cancelled() && hashFiles(format('{0}/package.json', inputs.plugin-key)) != '' }}


### PR DESCRIPTION
Avoid this warning in the CI:

![image](https://github.com/user-attachments/assets/644a64a2-0961-42ad-b482-f00c0789cd47)
https://github.com/pluginsGLPI/credit/actions/runs/15728403676/job/44323534953?pr=169

---
Another possibility, I don't know which is better? 

```
diff --git a/.github/workflows/continuous-integration.yml b/.github/workflows/continuous-integration.yml
index 29e7825..5548e3c 100644
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -83,7 +83,7 @@ jobs:
         shell: "bash"
         run: |
           sudo setfacl --recursive --modify u:www-data:rwx "${{ env.CACHE_DIR }}"
-          sudo setfacl --recursive --modify u:www-data:rwx /var/www/glpi/plugins
+          sudo chown --recursive www-data:www-data /var/www/glpi/plugins
       - name: "Install composer dependencies"
         if: ${{ !cancelled() && hashFiles(format('{0}/composer.json', inputs.plugin-key)) != '' }}
         run: |
```