### PR TITLE
Fix(Matrix): Use MariaDB 10.6

### DIFF
--- a/.github/workflows/generate-ci-matrix.yml
+++ b/.github/workflows/generate-ci-matrix.yml
@@ -60,7 +60,7 @@ jobs:
                     {"glpi-version": "11.0.x", "php-version": "8.3", "db-image": "mysql:8.4"},
                     {"glpi-version": "11.0.x", "php-version": "8.4", "db-image": "mysql:8.4"},
                     {"glpi-version": "11.0.x", "php-version": "8.4", "db-image": "mysql:8.0"},
-                    {"glpi-version": "11.0.x", "php-version": "8.4", "db-image": "mariadb:10.5"},
+                    {"glpi-version": "11.0.x", "php-version": "8.4", "db-image": "mariadb:10.6"},
                     {"glpi-version": "11.0.x", "php-version": "8.4", "db-image": "mariadb:11.4"}
                   ]
                 }


### PR DESCRIPTION
Since https://github.com/glpi-project/glpi/pull/20156

This PR updates the CI matrix accordingly to reflect this change.
Example of broken CI jobs due to this update:

* https://github.com/glpi-network/ansible/actions/runs/16069066694/job/45349368998?pr=75
* https://github.com/glpi-network/collaborativetools/actions/runs/16069009596/job/45349191502?pr=8