### PR TITLE
Fix(CSS Lint): Do not check for the presence of the stylelint binary.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -179,7 +179,7 @@ jobs:
             exit 1
           fi
       - name: "CSS Lint"
-        if: ${{ !cancelled() && hashFiles(format('{0}/node_modules/.bin/stylelint', inputs.plugin-key)) != '' && hashFiles(format('{0}/.stylelintrc.js', inputs.plugin-key)) != '' }}
+        if: ${{ !cancelled() && hashFiles(format('{0}/.stylelintrc.js', inputs.plugin-key)) != '' }}
         run: |
           echo -e "\033[0;33mExecuting Stylelint...\033[0m"
           if [[ -f "node_modules/.bin/stylelint" ]]; then


### PR DESCRIPTION
The Stylelint check is currently not functioning.

In this implementation, I follow the same approach as with JS Lint: I only verify the presence of the configuration file before invoking the GLPI binary, which is correctly installed.