### PR TITLE
Update CI matrix

### DIFF
--- a/.github/workflows/generate-ci-matrix.yml
+++ b/.github/workflows/generate-ci-matrix.yml
@@ -29,16 +29,13 @@ jobs:
               MATRIX='
                 {
                   "include": [
-                    {"glpi-version": "10.0.x", "php-version": "7.4", "db-image": "mysql:8.4"},
-                    {"glpi-version": "10.0.x", "php-version": "8.0", "db-image": "mysql:8.4"},
-                    {"glpi-version": "10.0.x", "php-version": "8.1", "db-image": "mysql:8.4"},
+                    {"glpi-version": "10.0.x", "php-version": "7.4", "db-image": "mariadb:10.2"},
+                    {"glpi-version": "10.0.x", "php-version": "8.0", "db-image": "mariadb:11.8"},
+                    {"glpi-version": "10.0.x", "php-version": "8.1", "db-image": "mysql:5.7"},
                     {"glpi-version": "10.0.x", "php-version": "8.2", "db-image": "mysql:8.4"},
                     {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mysql:8.4"},
                     {"glpi-version": "10.0.x", "php-version": "8.4", "db-image": "mysql:8.4"},
-                    {"glpi-version": "10.0.x", "php-version": "8.5", "db-image": "mysql:8.4"},
-                    {"glpi-version": "10.0.x", "php-version": "8.5", "db-image": "mysql:5.7"},
-                    {"glpi-version": "10.0.x", "php-version": "8.5", "db-image": "mariadb:10.2"},
-                    {"glpi-version": "10.0.x", "php-version": "8.5", "db-image": "mariadb:11.8"}
+                    {"glpi-version": "10.0.x", "php-version": "8.5", "db-image": "mysql:8.4"}
                   ]
                 }
               '
@@ -57,13 +54,10 @@ jobs:
               MATRIX='
                 {
                   "include": [
-                    {"glpi-version": "11.0.x", "php-version": "8.2", "db-image": "mysql:8.4"},
-                    {"glpi-version": "11.0.x", "php-version": "8.3", "db-image": "mysql:8.4"},
-                    {"glpi-version": "11.0.x", "php-version": "8.4", "db-image": "mysql:8.4"},
-                    {"glpi-version": "11.0.x", "php-version": "8.5", "db-image": "mysql:8.4"},
+                    {"glpi-version": "11.0.x", "php-version": "8.2", "db-image": "mariadb:10.6"},
+                    {"glpi-version": "11.0.x", "php-version": "8.3", "db-image": "mariadb:11.8"},
                     {"glpi-version": "11.0.x", "php-version": "8.4", "db-image": "mysql:8.0"},
-                    {"glpi-version": "11.0.x", "php-version": "8.5", "db-image": "mariadb:10.6"},
-                    {"glpi-version": "11.0.x", "php-version": "8.5", "db-image": "mariadb:11.8"}
+                    {"glpi-version": "11.0.x", "php-version": "8.5", "db-image": "mysql:8.4"}
                   ]
                 }
               '

--- a/.github/workflows/generate-ci-matrix.yml
+++ b/.github/workflows/generate-ci-matrix.yml
@@ -35,9 +35,10 @@ jobs:
                     {"glpi-version": "10.0.x", "php-version": "8.2", "db-image": "mysql:8.4"},
                     {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mysql:8.4"},
                     {"glpi-version": "10.0.x", "php-version": "8.4", "db-image": "mysql:8.4"},
-                    {"glpi-version": "10.0.x", "php-version": "8.4", "db-image": "mysql:5.7"},
-                    {"glpi-version": "10.0.x", "php-version": "8.4", "db-image": "mariadb:10.2"},
-                    {"glpi-version": "10.0.x", "php-version": "8.4", "db-image": "mariadb:11.4"}
+                    {"glpi-version": "10.0.x", "php-version": "8.5", "db-image": "mysql:8.4"},
+                    {"glpi-version": "10.0.x", "php-version": "8.5", "db-image": "mysql:5.7"},
+                    {"glpi-version": "10.0.x", "php-version": "8.5", "db-image": "mariadb:10.2"},
+                    {"glpi-version": "10.0.x", "php-version": "8.5", "db-image": "mariadb:11.8"}
                   ]
                 }
               '
@@ -46,7 +47,7 @@ jobs:
                 {
                   "include": [
                     {"glpi-version": "10.0.x", "php-version": "7.4", "db-image": "mariadb:10.2"},
-                    {"glpi-version": "10.0.x", "php-version": "8.4", "db-image": "mariadb:11.4"}
+                    {"glpi-version": "10.0.x", "php-version": "8.5", "db-image": "mariadb:11.8"}
                   ]
                 }
               '
@@ -59,9 +60,10 @@ jobs:
                     {"glpi-version": "11.0.x", "php-version": "8.2", "db-image": "mysql:8.4"},
                     {"glpi-version": "11.0.x", "php-version": "8.3", "db-image": "mysql:8.4"},
                     {"glpi-version": "11.0.x", "php-version": "8.4", "db-image": "mysql:8.4"},
+                    {"glpi-version": "11.0.x", "php-version": "8.5", "db-image": "mysql:8.4"},
                     {"glpi-version": "11.0.x", "php-version": "8.4", "db-image": "mysql:8.0"},
-                    {"glpi-version": "11.0.x", "php-version": "8.4", "db-image": "mariadb:10.6"},
-                    {"glpi-version": "11.0.x", "php-version": "8.4", "db-image": "mariadb:11.4"}
+                    {"glpi-version": "11.0.x", "php-version": "8.5", "db-image": "mariadb:10.6"},
+                    {"glpi-version": "11.0.x", "php-version": "8.5", "db-image": "mariadb:11.8"}
                   ]
                 }
               '
@@ -70,7 +72,7 @@ jobs:
                 {
                   "include": [
                     {"glpi-version": "11.0.x", "php-version": "8.2", "db-image": "mariadb:10.6"},
-                    {"glpi-version": "11.0.x", "php-version": "8.4", "db-image": "mariadb:11.4"}
+                    {"glpi-version": "11.0.x", "php-version": "8.5", "db-image": "mariadb:11.8"}
                   ]
                 }
               '


### PR DESCRIPTION
1. Change PHP max version to 8.5.
2. Change MariaDBmax version to 11.8.
3. Limit versions combinations in the generated CI matrix.