### PR TITLE
Fix: check common dependency

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -111,16 +111,19 @@ jobs:
           echo -e "\033[0;33mChecking for common dependencies between plugin and core...\033[0m"
           PLUGIN_DEPS=$(composer show --direct --format=json | jq -r '.installed[] | .name')
           CORE_DEPS=$(cd ../../ && composer show --direct --format=json | jq -r '.installed[] | .name')
-          HAS_MATCH=false
+          HAS_MATCH='false'
           for plugin_dep in $PLUGIN_DEPS; do
             for core_dep in $CORE_DEPS; do
               if [ "$plugin_dep" == "$core_dep" ] && [ "$plugin_dep" != "glpi-project/tools" ]; then
                 echo "❌ Conflict: '$plugin_dep' is present in both plugin and core."
-                HAS_MATCH=true
+                HAS_MATCH='true'
               fi
             done
           done
-          if $HAS_MATCH; then exit 1; fi
+          if [ "$HAS_MATCH" == 'true' ]; then
+            echo -e "\033[0;31mDependency conflicts detected. Please resolve them before proceeding.\033[0m"
+            exit 1
+          fi
           echo "✅ No dependency conflicts detected."
       - name: "Install npm dependencies"
         if: ${{ !cancelled() && hashFiles(format('{0}/package.json', inputs.plugin-key)) != '' }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -109,12 +109,12 @@ jobs:
         if: ${{ !cancelled() && hashFiles(format('{0}/composer.json', inputs.plugin-key)) != '' }}
         run: |
           echo -e "\033[0;33mChecking for common dependencies between plugin and core...\033[0m"
-          PLUGIN_DEPS=$(composer show --direct --format=json | jq -r '.installed[] | .name' | grep -v '^glpi-project/tools$')
+          PLUGIN_DEPS=$(composer show --direct --format=json | jq -r '.installed[] | .name')
           CORE_DEPS=$(cd ../../ && composer show --direct --format=json | jq -r '.installed[] | .name')
           HAS_MATCH=false
           for plugin_dep in $PLUGIN_DEPS; do
             for core_dep in $CORE_DEPS; do
-              if [ "$plugin_dep" == "$core_dep" ]; then
+              if [ "$plugin_dep" == "$core_dep" ] && [ "$plugin_dep" != "glpi-project/tools" ]; then
                 echo "❌ Conflict: '$plugin_dep' is present in both plugin and core."
                 HAS_MATCH=true
               fi

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -114,13 +114,13 @@ jobs:
           HAS_MATCH='false'
           for plugin_dep in $PLUGIN_DEPS; do
             for core_dep in $CORE_DEPS; do
-              if [ "$plugin_dep" == "$core_dep" ] && [ "$plugin_dep" != "glpi-project/tools" ]; then
+              if [[ "$plugin_dep" == "$core_dep" && "$plugin_dep" != "glpi-project/tools" ]]; then
                 echo "❌ Conflict: '$plugin_dep' is present in both plugin and core."
                 HAS_MATCH='true'
               fi
             done
           done
-          if [ "$HAS_MATCH" == 'true' ]; then
+          if [[ "$HAS_MATCH" == 'true' ]]; then
             echo -e "\033[0;31mDependency conflicts detected. Please resolve them before proceeding.\033[0m"
             exit 1
           fi


### PR DESCRIPTION
It fails when `composer.json` only contains `glpi-project/tools`.
Example:
https://github.com/pluginsGLPI/gantt/actions/runs/20049191041/job/57501278134