### PR TITLE
Fix: install jq when missing

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -108,6 +108,10 @@ jobs:
       - name: "Check for common dependencies"
         if: ${{ !cancelled() && hashFiles(format('{0}/composer.json', inputs.plugin-key)) != '' }}
         run: |
+          if [[ ! command -v jq &> /dev/null ]]; then
+            echo -e "\033[0;33mInstalling 'jq'...\033[0m"
+            sudo apt update && sudo apt install -y jq
+          fi
           echo -e "\033[0;33mChecking for common dependencies between plugin and core...\033[0m"
           PLUGIN_DEPS=$(composer show --direct --format=json | jq -r '.installed[] | .name')
           CORE_DEPS=$(cd ../../ && composer show --direct --format=json | jq -r '.installed[] | .name')


### PR DESCRIPTION
The CI with the php 7.4 image fails because the `jq` command is missing. I don't understand why it's missing, so as a workaround, I suggest installing it here.

<img width="781" height="224" alt="image" src="https://github.com/user-attachments/assets/1c688f3a-f88e-4b9e-aaa8-3fc3f893938b" />

https://github.com/pluginsGLPI/ldaptools/actions/runs/20741492283/job/59549057451