### PR TITLE
feat: Add support for native core tools

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -240,7 +240,7 @@ jobs:
             vendor/bin/licence-headers-check --ansi --no-interaction
           elif [[ -f "../../vendor/bin/licence-headers-check" ]]; then
             ../../vendor/bin/licence-headers-check --ansi --no-interaction --header-file=tools/HEADER -d .
-          elif [[ -f "../../bin/console" ]] && php ../../bin/console list 2>/dev/null | grep -q "tools:licence_headers_check"; then
+          elif [[ -f "../../bin/console" && -n "$(php ../../bin/console list | grep 'tools:licence_headers_check')" ]]; then
             echo -e "\033[0;33mUsing GLPI core tools:licence_headers_check command...\033[0m"
             php ../../bin/console tools:licence_headers_check --ansi --no-interaction --plugin=${{ inputs.plugin-key }}
           else

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -240,7 +240,7 @@ jobs:
             vendor/bin/licence-headers-check --ansi --no-interaction
           elif [[ -f "../../vendor/bin/licence-headers-check" ]]; then
             ../../vendor/bin/licence-headers-check --ansi --no-interaction --header-file=tools/HEADER -d .
-          elif [[ -f "../../bin/console" ]]; then
+          elif [[ -f "../../bin/console" ]] && php ../../bin/console list 2>/dev/null | grep -q "tools:licence_headers_check"; then
             echo -e "\033[0;33mUsing GLPI core tools:licence_headers_check command...\033[0m"
             php ../../bin/console tools:licence_headers_check --ansi --no-interaction --plugin=${{ inputs.plugin-key }}
           else

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -240,9 +240,9 @@ jobs:
             vendor/bin/licence-headers-check --ansi --no-interaction
           elif [[ -f "../../vendor/bin/licence-headers-check" ]]; then
             ../../vendor/bin/licence-headers-check --ansi --no-interaction --header-file=tools/HEADER -d .
-          elif [[ -f "/var/www/glpi/bin/console" ]]; then
+          elif [[ -f "../../bin/console" ]]; then
             echo -e "\033[0;33mUsing GLPI core tools:licence_headers_check command...\033[0m"
-            php /var/www/glpi/bin/console tools:licence_headers_check --ansi --no-interaction --plugin=${{ inputs.plugin-key }}
+            php ../../bin/console tools:licence_headers_check --ansi --no-interaction --plugin=${{ inputs.plugin-key }}
           else
             echo -e "\033[0;31mLicence headers check binary not found!\033[0m"
             exit 1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -232,7 +232,7 @@ jobs:
             echo -e "\033[0;31mStylelint binary not found!\033[0m"
             exit 1
           fi
-      - name: "Misc lint"
+      - name: "Licence header check"
         if: ${{ !cancelled() && hashFiles(format('{0}/tools/HEADER', inputs.plugin-key)) != '' }}
         run: |
           echo -e "\033[0;33mExecuting licence headers checks...\033[0m"
@@ -240,6 +240,9 @@ jobs:
             vendor/bin/licence-headers-check --ansi --no-interaction
           elif [[ -f "../../vendor/bin/licence-headers-check" ]]; then
             ../../vendor/bin/licence-headers-check --ansi --no-interaction --header-file=tools/HEADER -d .
+          elif [[ -f "/var/www/glpi/bin/console" ]]; then
+            echo -e "\033[0;33mUsing GLPI core tools:licence_headers_check command...\033[0m"
+            php /var/www/glpi/bin/console tools:licence_headers_check --ansi --no-interaction --plugin=${{ inputs.plugin-key }}
           else
             echo -e "\033[0;31mLicence headers check binary not found!\033[0m"
             exit 1


### PR DESCRIPTION
Adding fallback on native glpi core tools for licence-header-check (for the moment available only on nightly image) and will be available natively on GLPI 11.0.6