### PR TITLE
Feat: skip CHANGELOG check for automated PRs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -143,15 +143,22 @@ jobs:
             -f ../../tests/LDAP/ldif/10-users.ldif \
             -H ldap://openldap:389
       - name: "Check CHANGELOG update"
-        if: ${{ !cancelled() && !inputs.skip-changelog-check && github.event_name == 'pull_request' && (hashFiles(format('{0}/CHANGELOG.md', inputs.plugin-key)) != '' || hashFiles(format('{0}/CHANGELOG', inputs.plugin-key)) != '') }}
+        if: ${{ !cancelled() && !inputs.skip-changelog-check && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && (hashFiles(format('{0}/CHANGELOG.md', inputs.plugin-key)) != '' || hashFiles(format('{0}/CHANGELOG', inputs.plugin-key)) != '') }}
         shell: "bash"
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          changed=$(curl -s -H "Authorization: token $GH_TOKEN" \
+          pr_files=$(curl -s -H "Authorization: token $GH_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            | jq -r '[.[].filename] | any(test("CHANGELOG"; "i"))')
-          if [[ "$changed" != "true" ]]; then
+            | jq -r '{
+                has_changelog: ([.[].filename] | any(test("CHANGELOG"; "i"))),
+                exempt:        ([.[].filename] | all(test("^locales/|^\\.github/"; "i")))
+              }')
+          if [[ $(echo "$pr_files" | jq -r '.exempt') == "true" ]]; then
+            echo "✅ Locale/CI-only PR, skipping CHANGELOG check."
+            exit 0
+          fi
+          if [[ $(echo "$pr_files" | jq -r '.has_changelog') != "true" ]]; then
             echo "❌ CHANGELOG was not updated in this PR."
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The `db-image` parameter is a combination of the DB server engine (`mysql`, `mar
 An optional `init-script` parameter can be used to define the path of an initialization script. This script will be executed with `bash`.
 It can be used, for instance, to install a specific PHP extension.
 
+On pull requests, the workflow checks that the `CHANGELOG` file has been updated. This check is automatically skipped for Dependabot PRs and when all changed files are in `locales/` or `.github/` (e.g. locale-update PRs). It can also be fully disabled via the `skip-changelog-check` parameter.
+
 ## Generate CI matrix
 
 This workflow can be used to generate a matrix that contains the default PHP/SQL versions that are supported by the target GLPI version.


### PR DESCRIPTION
The CHANGELOG check now automatically skips Dependabot PRs (via actor check) and PRs where all changed files are in `locales/` or `.github/` (locale-update bots, CI-only changes). Mixed PRs that include code changes alongside locale files still require a CHANGELOG update.

- Enhancement of: https://github.com/glpi-project/plugin-ci-workflows/pull/55