### PR TITLE
Feat: Check plugin uninstall cleanliness

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -410,6 +410,7 @@ jobs:
               ['Checking for leftover plugin configuration...', "SELECT COUNT(*) FROM glpi_configs WHERE context = 'plugin:{$plugin_key}'",        'row(s) in glpi_configs'],
               ['Checking for leftover cron tasks...',           "SELECT COUNT(*) FROM glpi_crontasks WHERE itemtype LIKE '{$class_prefix}%' OR itemtype LIKE '{$ns_prefix}%'", 'row(s) in glpi_crontasks'],
               ['Checking for leftover profile rights...',       "SELECT COUNT(*) FROM glpi_profilerights WHERE name LIKE 'plugin_{$plugin_key}%'", 'row(s) in glpi_profilerights'],
+              ['Checking for leftover display preferences...',  "SELECT COUNT(*) FROM glpi_displaypreferences WHERE itemtype LIKE '{$class_prefix}%'", 'row(s) in glpi_displaypreferences'],
           ] as [$label, $sql, $entity]) {
               echo "\033[0;33m{$label}\033[0m\n";
               $count = (int) $db->query($sql)->fetch_row()[0];

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -374,3 +374,54 @@ jobs:
             echo -e "\033[0;31mTwigCS binary not found!\033[0m"
             exit 1
           fi
+      - name: "Check plugin uninstall cleanliness"
+        if: ${{ !cancelled() }}
+        working-directory: "/var/www/glpi"
+        run: |
+          echo -e "\033[0;33mDeactivating plugin...\033[0m"
+          bin/console plugin:deactivate --ansi --no-interaction ${{ inputs.plugin-key }}
+          echo -e "\033[0;33mUninstalling plugin...\033[0m"
+          bin/console plugin:uninstall --ansi --no-interaction ${{ inputs.plugin-key }}
+          cat > /tmp/check-uninstall.php << 'PHPEOF'
+          <?php
+          $plugin_key   = $argv[1] ?? '';
+          $class_prefix = 'Plugin' . ucfirst($plugin_key);
+          if ($plugin_key === '') {
+              fwrite(STDERR, "Usage: php check-uninstall.php <plugin-key>\n");
+              exit(1);
+          }
+          mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+          $db = new mysqli('db', 'root', '', 'glpi');
+          $failures = false;
+          echo "\033[0;33mChecking for leftover database tables...\033[0m\n";
+          $result = $db->query("SHOW TABLES LIKE 'glpi_plugin_{$plugin_key}%'");
+          $tables = [];
+          while ($row = $result->fetch_row()) {
+              $tables[] = $row[0];
+          }
+          if ($tables) {
+              echo "❌ Leftover tables after uninstall:\n" . implode("\n", $tables) . "\n";
+              $failures = true;
+          } else {
+              echo "✅ No leftover tables.\n";
+          }
+          foreach ([
+              ['Checking for leftover plugin configuration...', "SELECT COUNT(*) FROM glpi_configs WHERE context = 'plugin:{$plugin_key}'",        'row(s) in glpi_configs'],
+              ['Checking for leftover cron tasks...',           "SELECT COUNT(*) FROM glpi_crontasks WHERE itemtype LIKE '{$class_prefix}%'",      'row(s) in glpi_crontasks'],
+              ['Checking for leftover profile rights...',       "SELECT COUNT(*) FROM glpi_profilerights WHERE name LIKE 'plugin_{$plugin_key}%'", 'row(s) in glpi_profilerights'],
+          ] as [$label, $sql, $entity]) {
+              echo "\033[0;33m{$label}\033[0m\n";
+              $count = (int) $db->query($sql)->fetch_row()[0];
+              if ($count > 0) {
+                  echo "❌ {$count} leftover {$entity}.\n";
+                  $failures = true;
+              } else {
+                  echo "✅ None.\n";
+              }
+          }
+          if ($failures) {
+              fwrite(STDERR, "\033[0;31mPlugin uninstall left residual data in the database.\033[0m\n");
+              exit(1);
+          }
+          PHPEOF
+          php /tmp/check-uninstall.php ${{ inputs.plugin-key }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -386,6 +386,7 @@ jobs:
           <?php
           $plugin_key   = $argv[1] ?? '';
           $class_prefix = 'Plugin' . ucfirst($plugin_key);
+          $ns_prefix    = 'GlpiPlugin\\\\' . ucfirst($plugin_key) . '\\\\';
           if ($plugin_key === '') {
               fwrite(STDERR, "Usage: php check-uninstall.php <plugin-key>\n");
               exit(1);
@@ -394,7 +395,7 @@ jobs:
           $db = new mysqli('db', 'root', '', 'glpi');
           $failures = false;
           echo "\033[0;33mChecking for leftover database tables...\033[0m\n";
-          $result = $db->query("SHOW TABLES LIKE 'glpi_plugin_{$plugin_key}%'");
+          $result = $db->query("SHOW TABLES LIKE 'glpi_plugin_{$plugin_key}_%'");
           $tables = [];
           while ($row = $result->fetch_row()) {
               $tables[] = $row[0];
@@ -407,7 +408,7 @@ jobs:
           }
           foreach ([
               ['Checking for leftover plugin configuration...', "SELECT COUNT(*) FROM glpi_configs WHERE context = 'plugin:{$plugin_key}'",        'row(s) in glpi_configs'],
-              ['Checking for leftover cron tasks...',           "SELECT COUNT(*) FROM glpi_crontasks WHERE itemtype LIKE '{$class_prefix}%'",      'row(s) in glpi_crontasks'],
+              ['Checking for leftover cron tasks...',           "SELECT COUNT(*) FROM glpi_crontasks WHERE itemtype LIKE '{$class_prefix}%' OR itemtype LIKE '{$ns_prefix}%'", 'row(s) in glpi_crontasks'],
               ['Checking for leftover profile rights...',       "SELECT COUNT(*) FROM glpi_profilerights WHERE name LIKE 'plugin_{$plugin_key}%'", 'row(s) in glpi_profilerights'],
           ] as [$label, $sql, $entity]) {
               echo "\033[0;33m{$label}\033[0m\n";

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -1,0 +1,75 @@
+# Local CI testing with `act`
+
+[`act`](https://github.com/nektos/act) runs GitHub Actions locally inside Docker. Use it to validate changes to these workflows before pushing to `v1`.
+
+## Prerequisites
+
+- Docker running
+- `act` installed — see [installation](https://github.com/nektos/act?tab=readme-ov-file#installation)
+
+## One-time setup
+
+`act` prompts interactively for a Docker image on the first run. Pre-configure it to skip the prompt:
+
+```bash
+mkdir -p ~/.config/act
+echo '-P ubuntu-latest=catthehacker/ubuntu:act-latest' >> ~/.config/act/actrc
+```
+
+## Running the CI
+
+From the plugin directory, the command below redirects `uses: glpi-project/plugin-ci-workflows@v1` to your local checkout instead of fetching from GitHub.
+
+Two flags are always required when running a `workflow_call`-based workflow with `act`:
+
+- `-j ci` — the CI job depends on `generate-ci-matrix` for its matrix, which `act` cannot resolve dynamically; targeting the job directly bypasses that dependency
+- `--env GITHUB_WORKSPACE=<plugins-dir>` — `${{ github.workspace }}` resolves incorrectly in container `options:` under `act` + `workflow_call`; this makes it point to the directory that contains the plugin folder
+
+```bash
+cd /path/to/plugins/myplugin
+
+act push \
+  --local-repository "glpi-project/plugin-ci-workflows@v1=/path/to/plugin-ci-workflows" \
+  -W .github/workflows/continuous-integration.yml \
+  -j ci \
+  --matrix php-version:8.2 \
+  --env GITHUB_WORKSPACE=/path/to/plugins \
+  --pull=false \
+  --artifact-server-path ~/.cache/act-artifacts
+```
+
+`--artifact-server-path` runs a local cache server pour les steps `actions/cache` — Composer et npm sont restaurés depuis le disque au lieu du réseau. Créer le répertoire une fois avant le premier run :
+
+```bash
+mkdir -p ~/.cache/act-artifacts
+```
+
+Adapt three paths to your setup:
+
+| Placeholder | What it points to | Example |
+|---|---|---|
+| `/path/to/plugins/myplugin` | The plugin under test | `~/dev/GLPI/11.0-bf/plugins/fields` |
+| `/path/to/plugin-ci-workflows` | Your local checkout of this repo | `~/dev/plugin-ci-workflows` |
+| `/path/to/plugins` | The directory **containing** the plugin | `~/dev/GLPI/11.0-bf/plugins` |
+
+### First run
+
+The first run pulls the GLPI Docker image from `ghcr.io/glpi-project/githubactions-glpi-apache` (several GB). Drop `--pull=false` for that first run only, then add it back to reuse the cached image.
+
+## Simulating a pull request event
+
+Some steps only run on pull requests (CHANGELOG check, XML URL check). Pass a minimal event payload to trigger them:
+
+```bash
+cd /path/to/plugins/myplugin
+
+act pull_request \
+  --local-repository "glpi-project/plugin-ci-workflows@v1=/path/to/plugin-ci-workflows" \
+  -W .github/workflows/continuous-integration.yml \
+  -j ci \
+  --matrix php-version:8.2 \
+  --env GITHUB_WORKSPACE=/path/to/plugins \
+  --pull=false \
+  --artifact-server-path ~/.cache/act-artifacts \
+  --eventpath <(echo '{"pull_request":{"number":1},"repository":{"full_name":"glpi-project/myplugin"}}')
+```

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -38,7 +38,7 @@ act push \
   --artifact-server-path ~/.cache/act-artifacts
 ```
 
-`--artifact-server-path` runs a local cache server pour les steps `actions/cache` — Composer et npm sont restaurés depuis le disque au lieu du réseau. Créer le répertoire une fois avant le premier run :
+`--artifact-server-path` runs a local cache server for `actions/cache` steps — Composer and npm packages are restored from disk instead of the network. Create the directory once before the first run:
 
 ```bash
 mkdir -p ~/.cache/act-artifacts


### PR DESCRIPTION
Adds a "Check plugin uninstall cleanliness" step at the end of the CI pipeline that deactivates and uninstalls the plugin, then verifies no residual data remains in the database. The check covers the four most impactful cases:
- leftover plugin tables
- configuration rows in `glpi_configs`
- cron tasks in `glpi_crontasks`
- profile rights in `glpi_profilerights`

Also adds `docs/local-testing.md` documenting how to run the CI locally with act before pushing changes.