### PR TITLE
fix: Disable testdox chatty output on CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -392,7 +392,7 @@ jobs:
           fi
 
           if grep -qi 'testdox="true"' phpunit.xml; then
-            sed -i 's/ testdox="[Tt]rue"//g' phpunit.xml
+            sed -i 's/ testdox="true"//gI' phpunit.xml
           fi
 
           if [[ -f "vendor/bin/phpunit" ]]; then

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -391,6 +391,10 @@ jobs:
             PHP_FLAGS="-d pcov.enabled=1 -d pcov.directory=."
           fi
 
+          if grep -qi 'testdox="true"' phpunit.xml; then
+            sed -i 's/ testdox="[Tt]rue"//g' phpunit.xml
+          fi
+
           if [[ -f "vendor/bin/phpunit" ]]; then
             php $PHP_FLAGS vendor/bin/phpunit $PHPUNIT_FLAGS
           elif [[ -f "../../vendor/bin/phpunit" ]]; then


### PR DESCRIPTION
Sadly testdox fail steps is not put at the end, making it not very clear and easy to debug.

PHPUnit doesn't have an arg to disable it (one to enable it `--testdox`, so switching to a simple sed command