### PR TITLE
Feat: add glpi 12.0.x support to CI matrix generation

### DIFF
--- a/.github/workflows/generate-ci-matrix.yml
+++ b/.github/workflows/generate-ci-matrix.yml
@@ -55,14 +55,14 @@ jobs:
             },
             "12.0.x": {
               "minimal": [
-                {"php-version": "8.2", "db-image": "mariadb:10.6"},
-                {"php-version": "8.5", "db-image": "mariadb:11.8"}
+                {"php-version": "8.3", "db-image": "mariadb:10.11"},
+                {"php-version": "8.5", "db-image": "mariadb:12.3"}
               ],
               "complete": [
-                {"php-version": "8.2", "db-image": "mariadb:10.6"},
-                {"php-version": "8.3", "db-image": "mariadb:11.8"},
-                {"php-version": "8.4", "db-image": "mysql:8.0"},
-                {"php-version": "8.5", "db-image": "mysql:8.4"}
+                {"php-version": "8.3", "db-image": "mariadb:10.11"},
+                {"php-version": "8.4", "db-image": "mariadb:12.3"},
+                {"php-version": "8.5", "db-image": "mysql:8.0"},
+                {"php-version": "8.5", "db-image": "mysql:9.7"}
               ]
             }
           }

--- a/.github/workflows/generate-ci-matrix.yml
+++ b/.github/workflows/generate-ci-matrix.yml
@@ -24,52 +24,51 @@ jobs:
       - name: "Generate CI matrix"
         id: "generate-ci-matrix"
         run: |
-          if [[ "${{ inputs.glpi-version }}" = "10.0.x" ]]; then
-            if [[ "${{ inputs.complete-matrix && 'true' || 'false' }}" = "true" ]]; then
-              MATRIX='
-                {
-                  "include": [
-                    {"glpi-version": "10.0.x", "php-version": "7.4", "db-image": "mariadb:10.2"},
-                    {"glpi-version": "10.0.x", "php-version": "8.0", "db-image": "mariadb:11.8"},
-                    {"glpi-version": "10.0.x", "php-version": "8.1", "db-image": "mysql:5.7"},
-                    {"glpi-version": "10.0.x", "php-version": "8.2", "db-image": "mysql:8.4"},
-                    {"glpi-version": "10.0.x", "php-version": "8.3", "db-image": "mysql:8.4"},
-                    {"glpi-version": "10.0.x", "php-version": "8.4", "db-image": "mysql:8.4"},
-                    {"glpi-version": "10.0.x", "php-version": "8.5", "db-image": "mysql:8.4"}
-                  ]
-                }
-              '
-            else
-              MATRIX='
-                {
-                  "include": [
-                    {"glpi-version": "10.0.x", "php-version": "7.4", "db-image": "mariadb:10.2"},
-                    {"glpi-version": "10.0.x", "php-version": "8.5", "db-image": "mariadb:11.8"}
-                  ]
-                }
-              '
-            fi
-          elif [[ "${{ inputs.glpi-version }}" = "11.0.x" ]]; then
-            if [[ "${{ inputs.complete-matrix && 'true' || 'false' }}" = "true" ]]; then
-              MATRIX='
-                {
-                  "include": [
-                    {"glpi-version": "11.0.x", "php-version": "8.2", "db-image": "mariadb:10.6"},
-                    {"glpi-version": "11.0.x", "php-version": "8.3", "db-image": "mariadb:11.8"},
-                    {"glpi-version": "11.0.x", "php-version": "8.4", "db-image": "mysql:8.0"},
-                    {"glpi-version": "11.0.x", "php-version": "8.5", "db-image": "mysql:8.4"}
-                  ]
-                }
-              '
-            else
-              MATRIX='
-                {
-                  "include": [
-                    {"glpi-version": "11.0.x", "php-version": "8.2", "db-image": "mariadb:10.6"},
-                    {"glpi-version": "11.0.x", "php-version": "8.5", "db-image": "mariadb:11.8"}
-                  ]
-                }
-              '
-            fi
-          fi
-          echo "matrix=$(echo $MATRIX | jq -c .)" >> $GITHUB_OUTPUT
+          cat > /tmp/glpi-matrices.json << 'EOF'
+          {
+            "10.0.x": {
+              "minimal": [
+                {"php-version": "7.4", "db-image": "mariadb:10.2"},
+                {"php-version": "8.5", "db-image": "mariadb:11.8"}
+              ],
+              "complete": [
+                {"php-version": "7.4", "db-image": "mariadb:10.2"},
+                {"php-version": "8.0", "db-image": "mariadb:11.8"},
+                {"php-version": "8.1", "db-image": "mysql:5.7"},
+                {"php-version": "8.2", "db-image": "mysql:8.4"},
+                {"php-version": "8.3", "db-image": "mysql:8.4"},
+                {"php-version": "8.4", "db-image": "mysql:8.4"},
+                {"php-version": "8.5", "db-image": "mysql:8.4"}
+              ]
+            },
+            "11.0.x": {
+              "minimal": [
+                {"php-version": "8.2", "db-image": "mariadb:10.6"},
+                {"php-version": "8.5", "db-image": "mariadb:11.8"}
+              ],
+              "complete": [
+                {"php-version": "8.2", "db-image": "mariadb:10.6"},
+                {"php-version": "8.3", "db-image": "mariadb:11.8"},
+                {"php-version": "8.4", "db-image": "mysql:8.0"},
+                {"php-version": "8.5", "db-image": "mysql:8.4"}
+              ]
+            },
+            "12.0.x": {
+              "minimal": [
+                {"php-version": "8.2", "db-image": "mariadb:10.6"},
+                {"php-version": "8.5", "db-image": "mariadb:11.8"}
+              ],
+              "complete": [
+                {"php-version": "8.2", "db-image": "mariadb:10.6"},
+                {"php-version": "8.3", "db-image": "mariadb:11.8"},
+                {"php-version": "8.4", "db-image": "mysql:8.0"},
+                {"php-version": "8.5", "db-image": "mysql:8.4"}
+              ]
+            }
+          }
+          EOF
+          MODE="${{ inputs.complete-matrix && 'complete' || 'minimal' }}"
+          MATRIX=$(jq -c --arg v "${{ inputs.glpi-version }}" --arg m "$MODE" '
+            {include: (.[$v][$m] // error("unknown glpi-version: " + $v)) | map(. + {"glpi-version": $v})}
+          ' /tmp/glpi-matrices.json)
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The CI matrix generator now supports glpi-version 12.0.x, using the same PHP/database combinations as 11.0.x.
Matrix generation switched from a per-version if/elif chain to a JSON lookup table, so adding future GLPI versions no longer requires new conditional branches.
