### PR TITLE
Feat: add extra-env secret for PHPUnit step

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,6 +29,10 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      extra-env:
+        description: "Optional newline-separated KEY=VALUE pairs, exposed as environment variables during the PHPUnit step."
+        required: false
 
 jobs:
   ci:
@@ -379,10 +383,18 @@ jobs:
           sudo service apache2 start
       - name: "PHPUnit"
         if: ${{ !cancelled() && hashFiles(format('{0}/phpunit.xml', inputs.plugin-key)) != '' }}
+        env:
+          EXTRA_ENV: ${{ secrets.extra-env }}
         run: |
           echo -e "\033[0;33mExecuting PHPUnit...\033[0m"
           PHPUNIT_FLAGS="--colors=always"
           PHP_FLAGS=""
+
+          if [[ -n "$EXTRA_ENV" ]]; then
+            set -a
+            source <(echo "$EXTRA_ENV")
+            set +a
+          fi
 
           if [[ "${{ steps.coverage-config.outputs.coverage-enabled }}" == "true" ]]; then
             PHPUNIT_FLAGS="$PHPUNIT_FLAGS --coverage-text --coverage-cobertura=cobertura.xml --coverage-clover=clover.xml"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ jobs:
 
       # Whether to enable code coverage generation (default: false).
       code-coverage: true
+    secrets:
+      # Optional newline-separated KEY=VALUE pairs, exposed as environment
+      # variables during the PHPUnit step (e.g. tokens for tests hitting a
+      # live external API).
+      extra-env: |
+        MY_API_TOKEN=${{ secrets.MY_API_TOKEN }}
 ```
 
 The available `glpi-version`/`php-version` combinations corresponds to the `ghcr.io/glpi-project/githubactions-glpi-apache` images tags
@@ -68,6 +74,8 @@ The `db-image` parameter is a combination of the DB server engine (`mysql`, `mar
 
 An optional `init-script` parameter can be used to define the path of an initialization script. This script will be executed with `bash`.
 It can be used, for instance, to install a specific PHP extension.
+
+An optional `extra-env` secret can be used to expose additional environment variables during the PHPUnit step, for instance credentials required by tests that hit a live external API.
 
 On pull requests, the workflow checks that the `CHANGELOG` file has been updated. This check is automatically skipped for Dependabot PRs and when all changed files are in `locales/` or `.github/` (e.g. locale-update PRs). It can also be fully disabled via the `skip-changelog-check` parameter.
 


### PR DESCRIPTION
Plugins can now pass an optional `extra-env` secret with newline-separated KEY=VALUE pairs, exposed as environment variables during the PHPUnit step.
This allows tests that hit a live external API to receive credentials without hardcoding them in the workflow.