### PR TITLE
Feat: add vitest execution to CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -431,6 +431,18 @@ jobs:
             echo -e "\033[0;31mJest binary not found!\033[0m"
             exit 1
           fi
+      - name: "Vitest"
+        if: ${{ !cancelled() && (hashFiles(format('{0}/vitest.config.js', inputs.plugin-key)) != '' || hashFiles(format('{0}/vitest.config.ts', inputs.plugin-key)) != '' || hashFiles(format('{0}/vitest.config.mjs', inputs.plugin-key)) != '') }}
+        run: |
+          echo -e "\033[0;33mExecuting Vitest...\033[0m"
+          if [[ -f "node_modules/.bin/vitest" ]]; then
+            node_modules/.bin/vitest run --color
+          elif [[ -f "../../node_modules/.bin/vitest" ]]; then
+            ../../node_modules/.bin/vitest run --color
+          else
+            echo -e "\033[0;31mVitest binary not found!\033[0m"
+            exit 1
+          fi
       - name: "TwigCS"
         if: ${{ !cancelled() && hashFiles(format('{0}/.twig_cs.dist.php', inputs.plugin-key)) != '' }}
         run: |

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ If the vendor package is not installed within the plugin repository, the CI work
 | Licence headers check | _Natively since glpi 11.0.6_<br/> [glpi-project/tools](https://packagist.org/packages/glpi-project/tools) | `tools/HEADER`                                                                     |
 | PHPUnit               | [phpunit/phpunit](https://packagist.org/packages/phpunit/phpunit)                                         | `phpunit.xml`                                                                      |
 | Jest                  | [jest](https://www.npmjs.com/package/jest)                                                                | `jest.config.js`                                                                   |
+| Vitest                | [vitest](https://www.npmjs.com/package/vitest)                                                            | `vitest.config.js` or `vitest.config.ts` or `vitest.config.mjs`                    |
 | TwigCS                | [friendsoftwig/twigcs](https://github.com/friendsoftwig/twigcs)                                           | `.twig_cs.dist.php`                                                                |
 
 During the `PHPUnit` tests execution, GLPI will be accessible over HTTP (`http://localhost/`).


### PR DESCRIPTION
Plugins that ship a Vitest config now get their JS/TS tests run automatically as part of the CI workflow.